### PR TITLE
[fix] Add missing `from_str` annotation to the x25519.py stubs

### DIFF
--- a/pyrage-stubs/pyrage-stubs/x25519.py
+++ b/pyrage-stubs/pyrage-stubs/x25519.py
@@ -6,6 +6,10 @@ class Identity:
     def generate(cls) -> Identity:
         ...
 
+    @classmethod
+    def from_str(cls) -> Identity:
+        ...
+
     def to_public(self) -> Recipient:
         ...
 


### PR DESCRIPTION
Thank you for your work on pyrage!

When developing something using x25519 identities, I noticed that the stubs are missing an annotation for the `from_str` class method that was making my editor complain. This PR adds the missing annotation.