### PR TITLE
workflows/release: fix @v4 artifact action usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: upload linux dists
         uses: actions/upload-artifact@v4
         with:
-          name: pyrage-dists
+          name: pyrage-dists-linux
           path: dist/
 
   release-macos:
@@ -46,7 +46,7 @@ jobs:
       - name: upload macos dists
         uses: actions/upload-artifact@v4
         with:
-          name: pyrage-dists
+          name: pyrage-dists-macos
           path: dist/
 
   release-windows:
@@ -70,7 +70,7 @@ jobs:
       - name: upload windows dists
         uses: actions/upload-artifact@v4
         with:
-          name: pyrage-dists
+          name: pyrage-dists-windows
           path: dist/
 
   pypi-publish:
@@ -93,8 +93,9 @@ jobs:
       - name: fetch dists
         uses: actions/download-artifact@v4
         with:
-          name: pyrage-dists
+          pattern: pyrage-dists-*
           path: dist/
+          merge-multiple: true
 
       - name: publish
         uses: pypa/gh-action-pypi-publish@v1.8.11


### PR DESCRIPTION
I believe this is right, but there's only one way to find out.