### PR TITLE
Feature/plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,8 @@ dependencies = [
  "scrypt",
  "sha2",
  "subtle",
+ "which",
+ "wsl",
  "x25519-dalek",
  "zeroize",
 ]
@@ -87,6 +89,7 @@ dependencies = [
  "rand",
  "secrecy",
  "sha2",
+ "tempfile",
 ]
 
 [[package]]
@@ -135,6 +138,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "block-buffer"
@@ -335,10 +344,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fiat-crypto"
@@ -458,6 +489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -602,6 +642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,7 +774,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -973,7 +1019,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1043,6 +1089,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1222,6 +1281,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
+name = "tempfile"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1444,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,18 +1487,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -1424,10 +1532,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1436,10 +1556,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1448,16 +1580,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -1467,6 +1617,12 @@ checksum = "b67b5f0a4e7a27a64c651977932b9dc5667ca7fc31ac44b03ed37a0cf42fdfff"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 age-core = "0.10"
-age = { version = "0.10", features = ["ssh"] }
+age = { version = "0.10", features = ["ssh", "plugin"] }
 pyo3 = { version = "0.21", features = [
     "extension-module",
     "abi3",

--- a/pyrage-stubs/pyrage-stubs/__init__.pyi
+++ b/pyrage-stubs/pyrage-stubs/__init__.pyi
@@ -1,9 +1,9 @@
 from typing import Sequence, Union
 
-from pyrage import ssh, x25519, passphrase
+from pyrage import ssh, x25519, passphrase, plugin
 
-Identity = Union[ssh.Identity, x25519.Identity]
-Recipient = Union[ssh.Recipient, x25519.Recipient]
+Identity = Union[ssh.Identity, x25519.Identity, plugin.IdentityPluginV1]
+Recipient = Union[ssh.Recipient, x25519.Recipient, plugin.RecipientPluginV1]
 
 
 class RecipientError(Exception):

--- a/pyrage-stubs/pyrage-stubs/plugin.pyi
+++ b/pyrage-stubs/pyrage-stubs/plugin.pyi
@@ -1,0 +1,48 @@
+from __future__ import annotations
+from typing import Sequence, Self, Optional, Protocol
+
+
+class Callbacks(Protocol):
+    def display_message(self, message: str) -> None:
+        ...
+
+    def confirm(self, message: str, yes_string: str, no_string: Optional[str]) -> Optional[bool]:
+        ...
+
+    def request_public_string(self, description: str) -> Optional[str]:
+        ...
+
+    def request_passphrase(self, description: str) -> Optional[str]:
+        ...
+
+
+class Recipient:
+    @classmethod
+    def from_str(cls, v: str) -> Recipient:
+        ...
+
+    def plugin(self) -> str:
+        ...
+
+
+class RecipientPluginV1:
+    def __new__(cls, plugin_name: str, recipients: Sequence[Recipient], identities: Sequence[Identity], callbacks: Callbacks) -> Self:
+        ...
+
+
+class Identity:
+    @classmethod
+    def from_str(cls, v: str) -> Identity:
+        ...
+
+    @classmethod
+    def default_for_plugin(cls, plugin: str) -> Identity:
+        ...
+
+    def plugin(self) -> str:
+        ...
+
+
+class IdentityPluginV1:
+    def __new__(cls, plugin_name: str, identities: Sequence[Identity], callbacks: Callbacks) -> Self:
+        ...

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,0 +1,198 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use pyo3::{prelude::*, types::PyType};
+
+use crate::{DecryptError, EncryptError, IdentityError, RecipientError};
+
+/// Hack, because the orphan rule would prevent us from deriving a
+/// foreign trait on a foreign object. Instead, define a newtype.
+///
+/// Inner type is PyAny, because we do duck-typing at runtime, and
+/// declaring a protocol in the type stubs.
+#[derive(Clone)]
+pub(crate) struct PyCallbacks(Py<PyAny>);
+
+impl PyCallbacks {
+    fn new(inner: Bound<'_, PyAny>) -> PyResult<Self> {
+        Ok(Self(inner.unbind()))
+    }
+}
+
+// Since we have no way to pass errors from these callbacks, we might
+// as well panic.
+//
+// These callbacks don't look like they're supposed to fail anyway.
+impl age::Callbacks for PyCallbacks {
+    fn display_message(&self, message: &str) {
+        Python::with_gil(|py| {
+            self.0
+                .call_method1(py, pyo3::intern!(py, "display_message"), (message,))
+                .expect("`display_message` callback error")
+        });
+    }
+    fn confirm(&self, message: &str, yes_string: &str, no_string: Option<&str>) -> Option<bool> {
+        Python::with_gil(|py| {
+            self.0
+                .call_method1(
+                    py,
+                    pyo3::intern!(py, "confirm"),
+                    (message, yes_string, no_string),
+                )
+                .expect("`confirm` callback error")
+                .extract::<Option<bool>>(py)
+        })
+        .expect("type error in `confirm` callback")
+    }
+    fn request_public_string(&self, description: &str) -> Option<String> {
+        Python::with_gil(|py| {
+            self.0
+                .call_method1(
+                    py,
+                    pyo3::intern!(py, "request_public_string"),
+                    (description,),
+                )
+                .expect("`request_public_string` callback error")
+                .extract::<Option<String>>(py)
+        })
+        .expect("type error in `request_public_string` callback")
+    }
+    fn request_passphrase(&self, description: &str) -> Option<age::secrecy::SecretString> {
+        Python::with_gil(|py| {
+            self.0
+                .call_method1(py, pyo3::intern!(py, "request_passphrase"), (description,))
+                .expect("`request_passphrase` callback error")
+                .extract::<Option<String>>(py)
+        })
+        .expect("type error in `request_passphrase` callback")
+        .map(age::secrecy::SecretString::new)
+    }
+}
+
+#[pyclass(module = "pyrage.plugin")]
+#[derive(Clone)]
+pub(crate) struct Recipient(pub(crate) age::plugin::Recipient);
+
+#[pymethods]
+impl Recipient {
+    #[classmethod]
+    fn from_str(_cls: &Bound<'_, PyType>, v: &str) -> PyResult<Self> {
+        age::plugin::Recipient::from_str(v)
+            .map(Self)
+            .map_err(RecipientError::new_err)
+    }
+
+    fn plugin(&self) -> String {
+        self.0.plugin().to_owned()
+    }
+
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[pyclass(module = "pyrage.plugin")]
+#[derive(Clone)]
+pub(crate) struct Identity(pub(crate) age::plugin::Identity);
+
+#[pymethods]
+impl Identity {
+    #[classmethod]
+    fn from_str(_cls: &Bound<'_, PyType>, v: &str) -> PyResult<Self> {
+        age::plugin::Identity::from_str(v)
+            .map(Self)
+            .map_err(|e| IdentityError::new_err(e.to_string()))
+    }
+
+    #[classmethod]
+    fn default_for_plugin(_cls: &Bound<'_, PyType>, plugin: &str) -> Self {
+        Self(age::plugin::Identity::default_for_plugin(plugin))
+    }
+
+    fn plugin(&self) -> String {
+        self.0.plugin().to_owned()
+    }
+
+    fn __str__(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[pyclass(module = "pyrage.plugin")]
+#[derive(Clone)]
+pub(crate) struct RecipientPluginV1(pub(crate) Arc<age::plugin::RecipientPluginV1<PyCallbacks>>);
+
+#[pymethods]
+impl RecipientPluginV1 {
+    #[new]
+    #[pyo3(
+        text_signature = "(plugin_name: str, recipients: typing.Sequence[Recipient], identities: typing.Sequence[Identity], callbacks: Callbacks)"
+    )]
+    fn new(
+        _py: Python<'_>,
+        plugin_name: &str,
+        recipients: Vec<Recipient>,
+        identities: Vec<Identity>,
+        callbacks: Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        age::plugin::RecipientPluginV1::new(
+            plugin_name,
+            recipients
+                .into_iter()
+                .map(|i| i.0)
+                .collect::<Vec<_>>()
+                .as_slice(),
+            identities
+                .into_iter()
+                .map(|i| i.0)
+                .collect::<Vec<_>>()
+                .as_slice(),
+            PyCallbacks::new(callbacks)?,
+        )
+        .map(Arc::new)
+        .map(Self)
+        .map_err(|err| EncryptError::new_err(err.to_string()))
+    }
+}
+
+#[pyclass(module = "pyrage.plugin")]
+#[derive(Clone)]
+pub(crate) struct IdentityPluginV1(pub(crate) Arc<age::plugin::IdentityPluginV1<PyCallbacks>>);
+
+#[pymethods]
+impl IdentityPluginV1 {
+    #[new]
+    #[pyo3(
+        text_signature = "(plugin_name: str, identities: typing.Sequence[Identity], callbacks: Callbacks)"
+    )]
+    fn new(
+        _py: Python<'_>,
+        plugin_name: &str,
+        identities: Vec<Identity>,
+        callbacks: Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        age::plugin::IdentityPluginV1::new(
+            plugin_name,
+            identities
+                .into_iter()
+                .map(|i| i.0)
+                .collect::<Vec<_>>()
+                .as_slice(),
+            PyCallbacks::new(callbacks)?,
+        )
+        .map(Arc::new)
+        .map(Self)
+        .map_err(|err| DecryptError::new_err(err.to_string()))
+    }
+}
+
+pub(crate) fn module(py: Python<'_>) -> PyResult<Bound<'_, PyModule>> {
+    let module = PyModule::new_bound(py, "plugin")?;
+
+    module.add_class::<Recipient>()?;
+    module.add_class::<Identity>()?;
+    module.add_class::<RecipientPluginV1>()?;
+    module.add_class::<IdentityPluginV1>()?;
+
+    Ok(module)
+}


### PR DESCRIPTION
API surface exposed is equivalent to the Rust API, including plugin callbacks (exposed as `pyrage.plugin.Callbacks`, which must be subclassed for anything interesting to happen).

Non-`Clone`ability of plugin instances is resolved by putting them behind an `Arc`. Perhaps a more elegant solution could be produced later, by someone with more knowledge of PyO3 internals.

This was tested with rage's example `age-unencrypted-plugin` which happens to exercise the `display_message` callback, and additionally with `age-plugin-tpm` to exercise actual encryption functionality.

Typing stubs are amended to cover the new API surface.

Resolves #55.

EDIT 2024-03-29: now based on #63, which should be merged first.