### PR TITLE
Test and build on ARM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+          # Use 22.04, as 24.04 is unstable atm:
+          # https://github.com/orgs/community/discussions/148648#discussioncomment-11890717
+          - ubuntu-22.04-arm
         python:
           - "3.9"
           - "3.10"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,29 @@ jobs:
           name: pyrage-dists-linux
           path: dist/
 
+  release-linux-arm:
+    name: build Linux arm release dists
+    # Use 22.04, as 24.04 is unstable atm:
+    # https://github.com/orgs/community/discussions/148648#discussioncomment-11890717
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: build wheels
+        run: make dist-pyrage
+
+      - name: upload linux dists
+        uses: actions/upload-artifact@v4
+        with:
+          name: pyrage-dists-linux-arm
+          path: dist/
+
   release-macos:
     name: build macOS release dists
     runs-on: macos-latest
@@ -94,6 +117,7 @@ jobs:
       contents: write
     needs:
       - release-linux
+      - release-linux-arm
       - release-macos
       - release-windows
 


### PR DESCRIPTION
Run the tests on ARM in the CI pipeline and build manylinux ARM builds in the release pipeline. Use Ubuntu 22.04, as the Github Actions runners for 24.04 on ARM is unstable. Fixes #74.